### PR TITLE
Extending recursion limit

### DIFF
--- a/bpy.py
+++ b/bpy.py
@@ -80,6 +80,10 @@ def fix_types(in_file):
 
 
 def main():
+  # We get waaay past the 1000 limit even on relatively simple examples.
+  sys.setrecursionlimit(10000)
+
+
   parser = argparse.ArgumentParser()
   parser.set_defaults(func=lambda args: print('use --help to see commands'))
 


### PR DESCRIPTION
Testing on real samples fails because of a default recursion limit set pretty low.